### PR TITLE
Only show the welcome page the first time the extension starts

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,7 +17,8 @@
 			],
 			"preLaunchTask": "${defaultBuildTask}",
 			"env": {
-				"REDHAT_TELEMETRY_ENABLED": "true"
+				"REDHAT_TELEMETRY_ENABLED": "true",
+				"GRANITE_EXT_DEV_MODE": "true"
 			}
 		},
 		{
@@ -33,7 +34,8 @@
 			"preLaunchTask": "${defaultBuildTask}",
 			"env": {
 				"REDHAT_TELEMETRY_ENABLED": "false",
-				"MOCK_OLLAMA": "true"
+				"MOCK_OLLAMA": "true",
+				"GRANITE_EXT_DEV_MODE": "true"
 			}
 		}
 	]

--- a/src/commons/constants.ts
+++ b/src/commons/constants.ts
@@ -1,1 +1,2 @@
 export const EXTENSION_ID = 'redhat.vscode-granite';
+export const isDevMode = process.env.GRANITE_EXT_DEV_MODE === 'true';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,5 @@
 import { commands, ExtensionContext } from "vscode";
+import { isDevMode } from "./commons/constants";
 import { SetupGranitePage } from "./panels/setupGranitePage";
 import { Telemetry } from "./telemetry";
 
@@ -9,6 +10,9 @@ export async function activate(context: ExtensionContext) {
     SetupGranitePage.render(context.extensionUri, context.extensionMode);
   });
   context.subscriptions.push(setupGraniteCmd);
-  // TODO check initial startup status
-  return commands.executeCommand('vscode-granite.setup');
+  const hasRunBefore = context.globalState.get('hasRunSetup', false);
+  if (!hasRunBefore || isDevMode) {
+    await context.globalState.update('hasRunSetup', true);
+    return commands.executeCommand('vscode-granite.setup');
+  }
 }


### PR DESCRIPTION
added and store a flag in global storage (hasRunSetup) and tested against an environment variable (OLLAMA_MOCK). Once all the models are installed then the welcome page will not pop up