### PR TITLE
Fix disappearing labels

### DIFF
--- a/webviews/src/App.css
+++ b/webviews/src/App.css
@@ -165,7 +165,6 @@ button:disabled {
   font-weight: normal;
   text-wrap: nowrap;
   font-style: italic;
-  color: var(--vscode-terminal-background);
   padding: 5px 5px 0;
 }
 

--- a/webviews/src/ModelList.tsx
+++ b/webviews/src/ModelList.tsx
@@ -64,25 +64,15 @@ const ModelList: React.FC<ModelListProps> = ({ className, label, value, onChange
     const formatOptionLabel = (modelOption: ModelOption, { context }: { context: 'menu' | 'value' }) => {
         const isSelected = value === modelOption.value;
         const color = isSelected && context === 'menu' ? 'var(--vscode-quickInputList-focusForeground)' : 'var(--vscode-menu-foreground)';
+        const style = {
+            display: 'flex',
+            width: context === 'menu' ? '250px' : '210px',
+            justifyContent: 'space-between',
+        }
         return (
-            context === 'menu' ? 
-            <div style={
-                {
-                display: 'flex',
-                width: '250px',
-                justifyContent: 'space-between',
-            }}>
+            <div style={style}>
                 <span style={{ color }}>{modelOption.label}</span>
                 <span className='model-option--info' style={{ color }}>{modelOption.info}</span>
-            </div>
-            : 
-            <div style={
-                {
-                display: 'flex',
-                width: '250px',
-                justifyContent: 'space-between',
-            }}>
-                <span style={{ color }}>{modelOption.label}</span>
             </div>
         );
     };
@@ -90,9 +80,9 @@ const ModelList: React.FC<ModelListProps> = ({ className, label, value, onChange
     return (
         <div className="form-group">
             <div className='model-list--outer-wrapper'>
-                
+
                 <label className='model-list--label' htmlFor={label}>
-                    {status ? <FcCheckmark /> : <FcCancel />} 
+                    {status ? <FcCheckmark /> : <FcCancel />}
                     <span>{label}:</span>
                 </label>
 


### PR DESCRIPTION
Fixes:
- model size not shown by default
- info-label was not shown on certain themes (e.g. Solarized Light)

<img width="1037" alt="Screenshot 2024-10-04 at 16 01 28" src="https://github.com/user-attachments/assets/1c4c039e-ba0c-44b1-a32e-4441c9ffa3cc">
