### PR TITLE
Align with VS Code check icons

### DIFF
--- a/webviews/src/App.tsx
+++ b/webviews/src/App.tsx
@@ -2,8 +2,8 @@ import { vscode } from "./utils/vscode";
 import "./App.css";
 import { useCallback, useEffect, useState } from "react";
 import ModelList, { ModelOption } from "./ModelList";
-import { FcCancel, FcCheckmark } from "react-icons/fc";
 import { ProgressData } from "../../src/commons/progressData";
+import { StatusCheck } from "./StatusCheck";
 
 
 function App() {
@@ -150,7 +150,7 @@ function App() {
         <div className="form-group">
           <div className="ollama-status-wrapper">
             <label>
-              {status === 'installed' ? <FcCheckmark /> : <FcCancel />}
+              <StatusCheck checked={status === 'installed'} />
               <span>Ollama status:</span>
               <span>{status}</span>
             </label>

--- a/webviews/src/ModelList.tsx
+++ b/webviews/src/ModelList.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import Select from 'react-select';
-import { FcCancel, FcCheckmark } from "react-icons/fc";
 import { ProgressData } from '../../src/commons/progressData';
 import ProgressBar from './ProgressBar';
+import { StatusCheck } from './StatusCheck';
 
 export interface ModelOption {
     label: string;
@@ -82,7 +82,7 @@ const ModelList: React.FC<ModelListProps> = ({ className, label, value, onChange
             <div className='model-list--outer-wrapper'>
 
                 <label className='model-list--label' htmlFor={label}>
-                    {status ? <FcCheckmark /> : <FcCancel />}
+                    <StatusCheck checked={status} />
                     <span>{label}:</span>
                 </label>
 

--- a/webviews/src/StatusCheck.tsx
+++ b/webviews/src/StatusCheck.tsx
@@ -1,0 +1,12 @@
+import { VscCircleLarge, VscPassFilled } from "react-icons/vsc";
+
+export interface StatusCheckProps {
+  checked: boolean
+}
+
+export const StatusCheck: React.FC<StatusCheckProps> = ({ checked }: StatusCheckProps) => {
+  return (checked ?
+    <VscPassFilled color="var(--vscode-textLink-foreground)" /> :
+    <VscCircleLarge />
+  );
+};


### PR DESCRIPTION
Changed the check icons to provide a LnF closer to VS Code's:

<img width="1188" alt="Screenshot 2024-10-04 at 17 34 07" src="https://github.com/user-attachments/assets/d5d78b9b-09de-4411-a652-4ed6a7d62162">
<img width="1234" alt="Screenshot 2024-10-04 at 17 34 24" src="https://github.com/user-attachments/assets/deed33ba-b046-402f-a262-b134caa77094">
<img width="1229" alt="Screenshot 2024-10-04 at 17 34 54" src="https://github.com/user-attachments/assets/30940c0f-4b34-4368-be7c-f7e095ce39d1">

this better aligns with VS Code walkthrough UI:
<img width="1298" alt="Screenshot 2024-10-04 at 17 39 26" src="https://github.com/user-attachments/assets/011e575a-3dc0-46f7-a112-c4e14940fea7">
 

