### PR TITLE
Rewrite model and server statuses to support model updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@redhat-developer/vscode-redhat-telemetry": "^0.9.0"
+        "@redhat-developer/vscode-redhat-telemetry": "^0.9.0",
+        "cheerio": "^1.0.0"
       },
       "devDependencies": {
         "@types/mocha": "^10.0.8",
@@ -1244,6 +1245,11 @@
         "node": ">= 6"
       }
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
+    },
     "node_modules/brace-expansion": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
@@ -1385,6 +1391,46 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/cheerio": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0.tgz",
+      "integrity": "sha512-quS9HgjQpdaXOvsZz82Oz7uxtXiy6UIsIQcpBj7HRw2M63Skasm9qlDocAM7jNuaxdhpPU7c4kJN+gA5MCu4ww==",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.1.0",
+        "encoding-sniffer": "^0.2.0",
+        "htmlparser2": "^9.1.0",
+        "parse5": "^7.1.2",
+        "parse5-htmlparser2-tree-adapter": "^7.0.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^6.19.5",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18.17"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/chokidar": {
@@ -1547,6 +1593,32 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-select": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
+      "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
+      "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/data-view-buffer": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.1.tgz",
@@ -1700,6 +1772,57 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ]
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
+      "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/dset": {
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.4.tgz",
@@ -1720,6 +1843,18 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true
     },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.0.tgz",
+      "integrity": "sha512-ju7Wq1kg04I3HtiYIOrUrdfdDvkyO9s5XM8QAj/bN61Yo/Vb4vgJxy5vi4Yxk01gWHbrofpPtpxM8bKger9jhg==",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+      }
+    },
     "node_modules/end-of-stream": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
@@ -1739,6 +1874,17 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/error-ex": {
@@ -2606,6 +2752,24 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
     },
+    "node_modules/htmlparser2": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.1.0.tgz",
+      "integrity": "sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.1.0",
+        "entities": "^4.5.0"
+      }
+    },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -2638,6 +2802,17 @@
       "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
       "engines": {
         "node": ">=8.12.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ieee754": {
@@ -3830,6 +4005,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
     "node_modules/object-hash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
@@ -4126,6 +4312,40 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
+      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
+      "dependencies": {
+        "entities": "^4.4.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.0.0.tgz",
+      "integrity": "sha512-B77tOZrqqfUfnVcOrUvfdLbz4pu4RopLD/4vmu3HUPswwTA8OH0EMW9BlWR2B0RCoiZRAHEUu7IxeP1Pd1UU+g==",
+      "dependencies": {
+        "domhandler": "^5.0.2",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "dependencies": {
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/path-exists": {
@@ -4555,6 +4775,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/semver": {
       "version": "7.6.3",
@@ -5204,6 +5429,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.19.8.tgz",
+      "integrity": "sha512-U8uCCl2x9TK3WANvmBavymRzxbfFYG+tAu+fgx3zxQy3qdagQqBLwJVrdyO1TBfUXvfKveMKJZhpvUYoOjM+4g==",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.19.8",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
@@ -5265,6 +5498,25 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "typescript": "^5.6.2"
   },
   "dependencies": {
-    "@redhat-developer/vscode-redhat-telemetry": "^0.9.0"
+    "@redhat-developer/vscode-redhat-telemetry": "^0.9.0",
+    "cheerio": "^1.0.0"
   }
 }

--- a/src/commons/constants.ts
+++ b/src/commons/constants.ts
@@ -1,2 +1,4 @@
 export const EXTENSION_ID = 'redhat.vscode-granite';
 export const isDevMode = process.env.GRANITE_EXT_DEV_MODE === 'true';
+export const DOWNLOADABLE_MODELS = ['nomic-embed-text:latest', 'granite-code:3b', 'granite-code:8b', 'granite-code:20b', 'granite-code:34b'];
+

--- a/src/commons/modelInfo.ts
+++ b/src/commons/modelInfo.ts
@@ -1,0 +1,35 @@
+export const DEFAULT_MODEL_INFO = new Map<string, ModelInfo>();
+[{
+  id: 'nomic-embed-text:latest',
+  size: '274MB',
+  digest: ''
+},
+{
+  id: 'granite-code:3b',
+  size: '274MB',
+  digest: ''
+},
+{
+  id: 'granite-code:8b',
+  size: '4GB',
+  digest: ''
+},
+{
+  id: 'granite-code:20b',
+  size: '12GB',
+  digest: ''
+},
+{
+  id: 'granite-code:34b',
+  size: '20GB',
+  digest: ''
+}
+].forEach((m: ModelInfo) => {
+  DEFAULT_MODEL_INFO.set(m.id, m);
+});
+
+export interface ModelInfo {
+  id: string;
+  size: string;
+  digest: string;
+}

--- a/src/commons/naming.ts
+++ b/src/commons/naming.ts
@@ -1,0 +1,3 @@
+export function getStandardName(modelName: string): string {
+  return modelName.includes(":") ? modelName : `${modelName}:latest`;
+}

--- a/src/commons/statuses.ts
+++ b/src/commons/statuses.ts
@@ -1,0 +1,7 @@
+export enum ServerStatus {
+  unknown, stopped, started, installing, missing
+}
+
+export enum ModelStatus {
+  unknown, installed, installing, missing, stale
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,6 @@
 import { commands, ExtensionContext } from "vscode";
-import { isDevMode } from "./commons/constants";
+import { DOWNLOADABLE_MODELS, isDevMode } from "./commons/constants";
+import { ollamaLibraryWarmup } from "./ollama/ollamaLibrary";
 import { SetupGranitePage } from "./panels/setupGranitePage";
 import { Telemetry } from "./telemetry";
 
@@ -7,10 +8,12 @@ export async function activate(context: ExtensionContext) {
   await Telemetry.initialize(context);
   const setupGraniteCmd = commands.registerCommand("vscode-granite.setup", async () => {
     await Telemetry.send("granite.commands.setup");
+    await ollamaLibraryWarmup(DOWNLOADABLE_MODELS);
     SetupGranitePage.render(context.extensionUri, context.extensionMode);
   });
   context.subscriptions.push(setupGraniteCmd);
   const hasRunBefore = context.globalState.get('hasRunSetup', false);
+
   if (!hasRunBefore || isDevMode) {
     await context.globalState.update('hasRunSetup', true);
     return commands.executeCommand('vscode-granite.setup');

--- a/src/modelServer.ts
+++ b/src/modelServer.ts
@@ -1,11 +1,12 @@
 import { ProgressData } from "./commons/progressData";
+import { ModelStatus, ServerStatus } from "./commons/statuses";
 
 export interface IModelServer {
   getName(): string;
-  isServerInstalled(): Promise<boolean>;
+  getStatus(): Promise<ServerStatus>;
   startServer(): Promise<boolean>;
   installServer(mode: string): Promise<boolean>;
-  isModelInstalled(modelName: string): Promise<boolean>;
+  getModelStatus(modelName?: string): Promise<ModelStatus>
   installModel(modelName: string, reportProgress: (progress: ProgressData) => void): Promise<any>;
   supportedInstallModes(): Promise<{ id: string; label: string }[]>; //manual, script, homebrew
   configureAssistant(
@@ -14,4 +15,5 @@ export interface IModelServer {
     embeddingsModel: string | null
   ): Promise<void>;
   listModels(): Promise<string[]>;
+  //getModelInfo(modelName: string): Promise<ModelInfo | undefined>;
 }

--- a/src/ollama/mockServer.ts
+++ b/src/ollama/mockServer.ts
@@ -1,14 +1,15 @@
 //Mock server for testing
 import { CancellationError, env, Progress, ProgressLocation, Uri, window } from "vscode";
+import { getStandardName } from "../commons/naming";
 import { ProgressData } from "../commons/progressData";
+import { ModelStatus, ServerStatus } from "../commons/statuses";
 import { IModelServer } from "../modelServer";
 import { OllamaServer } from "./ollamaServer";
 class MockModel {
   progress: number;
   layers: MockLayer[];
-  constructor(public name: string, public size: number, public installed: boolean = false) {
+  constructor(public name: string, public size: number, public status: ModelStatus = ModelStatus.missing) {
     this.progress = 0;
-    this.installed = false;
     const sizeInBytes = size * 1024 * 1024;
     this.layers = this.generateLayers(sizeInBytes);
   }
@@ -32,13 +33,13 @@ interface MockLayer {
   progress: number; // progress in bytes
 }
 export class MockServer extends OllamaServer implements IModelServer {
-  private isInstalled: boolean = false;
+  private mockStatus = ServerStatus.missing;
   private models: Map<string, MockModel> = new Map([
     ["granite-code:3b", new MockModel("granite-code:3b", 2600)],
     ["granite-code:8b", new MockModel("granite-code:8b", 4000)],
-    ["granite-code:20b", new MockModel("granite-code:20b", 11000, true)],
+    ["granite-code:20b", new MockModel("granite-code:20b", 11000, ModelStatus.installed)],
     ["granite-code:34b", new MockModel("granite-code:34b", 20000)],
-    ["nomic-embed-text:latest", new MockModel("nomic-embed-text:latest", 274)]
+    ["nomic-embed-text:latest", new MockModel("nomic-embed-text:latest", 274, ModelStatus.stale)],
   ]);
 
   /**
@@ -53,14 +54,25 @@ export class MockServer extends OllamaServer implements IModelServer {
     this.speed *= 1024 * 1024; // Convert speed to bytes per second
   }
   async startServer(): Promise<boolean> {
+    this.mockStatus = ServerStatus.started;
     return true;
   }
-  async isServerInstalled(): Promise<boolean> {
-    return this.isInstalled;
+  async isServerStarted(): Promise<boolean> {
+    return this.mockStatus === ServerStatus.started;
   }
+
+  async isServerInstalled(): Promise<boolean> {
+    return this.mockStatus === ServerStatus.started || this.mockStatus === ServerStatus.stopped;
+  }
+
+  async getStatus(): Promise<ServerStatus> {
+    return this.mockStatus;
+  }
+
   async installServer(mode: string): Promise<boolean> {
     switch (mode) {
       case "mock":
+        this.mockStatus = ServerStatus.installing;
         return new Promise(async (resolve, reject) => {
           await window.withProgress(
             {
@@ -86,8 +98,8 @@ export class MockServer extends OllamaServer implements IModelServer {
                   await new Promise(resolve => setTimeout(resolve, interval));
                   await updateProgress();
                 } else {
-                  this.isInstalled = true;
-                  resolve(this.isInstalled);
+                  this.mockStatus = ServerStatus.started;
+                  resolve(true);
                 }
               };
 
@@ -98,12 +110,12 @@ export class MockServer extends OllamaServer implements IModelServer {
       case "manual":
       default:
         await env.openExternal(Uri.parse("https://ollama.com/download"));
-        this.isInstalled = true;
-        return this.isInstalled;
+        this.mockStatus = ServerStatus.started;
+        return true;
     }
   }
   private getModel(modelName: string): MockModel {
-    const fullModelName = modelName.includes(":") ? modelName : `${modelName}:latest`;
+    const fullModelName = getStandardName(modelName);
     const model = this.models.get(fullModelName);
     if (!model) {
       throw new Error(`Model ${fullModelName} not found`);
@@ -111,13 +123,20 @@ export class MockServer extends OllamaServer implements IModelServer {
     return model;
   }
 
-  async isModelInstalled(modelName: string): Promise<boolean> {
-    return this.getModel(modelName).installed;
+  async getModelStatus(modelName?: string): Promise<ModelStatus> {
+    if (!modelName || !(await this.isServerStarted())) {
+      return ModelStatus.unknown;
+    }
+    // Check if the model is currently being installed
+    if (this.installingModels.has(modelName)) {
+      return ModelStatus.installing;
+    }
+    return this.getModel(modelName).status;
   }
 
   async cancellablePullModel(modelName: string, progressReporter: Progress<ProgressData>, token: any): Promise<void> {
     const model = this.getModel(modelName);
-    if (model.installed) {
+    if (model.status === ModelStatus.installed) {
       return;
     }
 
@@ -140,7 +159,7 @@ export class MockServer extends OllamaServer implements IModelServer {
         await this.simulateStep(model.name, step.name, step.duration, progressReporter);
       }
     }
-    model.installed = true;
+    model.status = ModelStatus.installed;
   }
 
   private async simulateStep(modelName: string, status: string, duration: number, progressReporter: Progress<ProgressData>): Promise<void> {
@@ -204,10 +223,10 @@ export class MockServer extends OllamaServer implements IModelServer {
   }
 
   async listModels(): Promise<string[]> {
-    if (!this.isInstalled) {
+    if (!this.isServerInstalled()) {
       throw new Error("Server is not installed");
     }
-    return Array.from(this.models.values()).filter(model => model.installed).map(model => model.name);
+    return Array.from(this.models.values()).filter(model => model.status !== ModelStatus.missing).map(model => model.name);
   }
 
   async configureAssistant(

--- a/src/ollama/ollamaLibrary.ts
+++ b/src/ollama/ollamaLibrary.ts
@@ -1,0 +1,64 @@
+import * as cheerio from 'cheerio';
+import { ModelInfo } from '../commons/modelInfo';
+
+const cache = new Map<string, ModelInfo | undefined>();//TODO limit caching lifespan
+
+const INFO_DELIMITER = ' . ';
+
+// This is fugly, extremely brittle, but we have no other choice because The ollama library doesn't seem to expose an API we can query.
+export async function getRemoteModelInfo(modelId: string): Promise<ModelInfo | undefined> {
+  // Check if the result is already cached
+  if (cache.has(modelId)) {
+    return cache.get(modelId);
+  }
+  const start = Date.now();
+
+  const url = `https://ollama.com/library/${modelId}`;
+  try {
+    const response = await fetch(url, { signal: AbortSignal.timeout(3000) });
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch the model page: ${response.statusText}`);
+    }
+
+    const html = await response.text();
+    const $ = cheerio.load(html);
+    const fileExplorer = $('#file-explorer');
+    const itemsCenter = fileExplorer.find('.items-center');
+    const lastParagraphElement = itemsCenter.find('p').last();
+
+    if (lastParagraphElement.length > 0) {
+      const lastParagraph = lastParagraphElement.text().trim();
+      if (lastParagraph.includes(INFO_DELIMITER)) {
+        const [digest, size] = lastParagraph.split(INFO_DELIMITER).map(item => item.trim());
+        const data: ModelInfo = {
+          id: modelId,
+          size,
+          digest
+        };
+        // Cache the successful result
+        cache.set(modelId, data);
+        console.log('Model info:', data);
+        return data;
+      }
+    }
+  } catch (error) {
+    console.error(`Error fetching or parsing model info: ${error}`);
+  } finally {
+    const elapsed = Date.now() - start;
+    console.log(`Fetched remote information for ${modelId} in ${elapsed} ms`);
+  }
+
+  // Cache the failure
+  cache.set(modelId, undefined);
+  return undefined;
+}
+
+export async function ollamaLibraryWarmup(models: string[]): Promise<void> {
+  const start = Date.now();
+  await Promise.all(models.map(async (id) => {
+    await getRemoteModelInfo(id);
+  }));
+  const elapsed = Date.now() - start;
+  console.log(`Warmed up ${models.length} model info in ${elapsed} ms`);
+}

--- a/src/panels/setupGranitePage.ts
+++ b/src/panels/setupGranitePage.ts
@@ -11,7 +11,9 @@ import {
   WebviewPanel,
   window
 } from "vscode";
+import { DOWNLOADABLE_MODELS } from '../commons/constants';
 import { ProgressData } from "../commons/progressData";
+import { ModelStatus, ServerStatus } from '../commons/statuses';
 import { IModelServer } from '../modelServer';
 import { MockServer } from '../ollama/mockServer';
 import { OllamaServer } from '../ollama/ollamaServer';
@@ -224,7 +226,7 @@ export class SetupGranitePage {
       async (message: any) => {
         const command = message.command;
         const data = message.data;
-        let ollamaInstalled: boolean | undefined;
+
         switch (command) {
           case "init":
             webview.postMessage({
@@ -251,34 +253,7 @@ export class SetupGranitePage {
             }
             this.debounceStatus = now;
 
-            // console.log("Received fetchStatus msg " + debounceStatus);
-            let models: string[];
-            try {
-              models = await this.server.listModels();
-              ollamaInstalled = true;
-            } catch (e) {
-              //TODO check error response code instead?
-              models = [];
-              if (!ollamaInstalled) {
-                //fall back to checking CLI
-                ollamaInstalled = await this.server.isServerInstalled();
-                if (ollamaInstalled) {
-                  try {
-                    await this.server.startServer();
-                    models = await this.server.listModels();
-                  } catch (e) { }
-                }
-              }
-            }
-            //TODO check selected models statuses
-            //Respond with configuration status when init command is received
-            webview.postMessage({
-              command: "status",
-              data: {
-                ollamaInstalled,
-                models,
-              },
-            });
+            this.publishStatus(webview);
             break;
           case "setupGranite":
             async function reportProgress(progress: ProgressData) {
@@ -296,7 +271,7 @@ export class SetupGranitePage {
               },
             });
             try {
-              await this.setupGranite(data as GraniteConfiguration, reportProgress);
+              await this.setupGranite(data as GraniteConfiguration, reportProgress, webview);
             } finally {
               webview.postMessage({
                 command: "page-update",
@@ -313,47 +288,81 @@ export class SetupGranitePage {
     );
   }
 
+  async getModelStatuses(): Promise<Map<string, ModelStatus>> {
+    const modelStatuses: Map<string, ModelStatus> = new Map();
+    await Promise.all(DOWNLOADABLE_MODELS.map(async (id) => {
+      const status = await this.server.getModelStatus(id);
+      modelStatuses.set(id, status);
+    }));
+    return modelStatuses;
+  }
+
+  async publishStatus(webview: Webview) {
+    // console.log("Received fetchStatus msg " + debounceStatus);
+    const serverStatus = await this.server.getStatus();
+    if (serverStatus === ServerStatus.stopped) {
+      // TODO Try starting the server automatically or let the user start it manually?
+      // await this.server.startServer();
+      // serverStatus = await this.server.getStatus();
+    }
+    const modelStatuses = await this.getModelStatuses();
+    const modelStatusesObject = Object.fromEntries(modelStatuses); // Convert Map to Object
+    webview.postMessage({
+      command: "status",
+      data: {
+        serverStatus,
+        modelStatuses: modelStatusesObject
+      },
+    });
+  }
+
   async setupGranite(
-    graniteConfiguration: GraniteConfiguration, reportProgress: (progress: ProgressData) => void
-  ): Promise<void> {
+    graniteConfiguration: GraniteConfiguration, reportProgress: (progress: ProgressData) => void, webview: Webview): Promise<void> {
     //TODO handle continue (conflicting) onboarding page
 
     console.log("Starting Granite Code AI-Assistant configuration...");
-
+    const chatModel = graniteConfiguration.chatModelId;
+    const tabModel = graniteConfiguration.tabModelId;
+    const embeddingsModel = graniteConfiguration.embeddingsModelId;
     // Collect all unique models to install from graniteConfiguration
-    const modelsToInstall = new Set<string>();
-    if (graniteConfiguration.chatModelId !== null) {
-      modelsToInstall.add(graniteConfiguration.chatModelId);
+    const modelsToInstall: string[] = []; //I'd prefer using a sorted set but there's no such thing in vanilla typescript
+    if (chatModel !== null && !modelsToInstall.includes(chatModel)) {
+      modelsToInstall.push(chatModel);
     }
-    if (graniteConfiguration.tabModelId !== null) {
-      modelsToInstall.add(graniteConfiguration.tabModelId);
+    if (tabModel !== null && !modelsToInstall.includes(tabModel)) {
+      modelsToInstall.push(tabModel);
     }
-    if (graniteConfiguration.embeddingsModelId !== null) {
-      modelsToInstall.add(graniteConfiguration.embeddingsModelId);
+    if (embeddingsModel !== null && !modelsToInstall.includes(embeddingsModel)) {
+      modelsToInstall.push(embeddingsModel);
     }
 
     try {
       // Attempt to install the required models
       for (const model of modelsToInstall) {
-        if (await this.server.isModelInstalled(model)) {
-          console.log(`${model} is already installed`);
-        } else {
+        const modelStatus = await this.server.getModelStatus(model);
+        if (modelStatus !== ModelStatus.installed) {
+          if (modelStatus === ModelStatus.stale) {
+            console.log(`${model} is already installed, it will be updated`);
+          } else {
+            console.log(`Installing ${model}`);
+          }
           await this.server.installModel(model, reportProgress);
+          this.publishStatus(webview);
           await Telemetry.send("granite.setup.model.install", { model });
         }
       }
 
       // After installing models, configure the assistant
       await this.server.configureAssistant(
-        graniteConfiguration.chatModelId,
-        graniteConfiguration.tabModelId,
-        graniteConfiguration.embeddingsModelId
+        chatModel,
+        tabModel,
+        embeddingsModel
       );
       console.log("Granite Code AI-Assistant setup complete");
       await Telemetry.send("granite.setup.success", {
-        chatModelId: graniteConfiguration.chatModelId ?? 'none',
-        tabModelId: graniteConfiguration.tabModelId ?? 'none',
-        embeddingsModelId: graniteConfiguration.embeddingsModelId ?? 'none',
+        chatModelId: chatModel ?? 'none',
+        tabModelId: tabModel ?? 'none',
+        embeddingsModelId: embeddingsModel ?? 'none',
       });
     } catch (error: any) {
       //if error is CancellationError, then we can ignore it
@@ -363,9 +372,9 @@ export class SetupGranitePage {
       // Generic error handling for all errors
       await Telemetry.send("granite.setup.error", {
         error: error?.message ?? 'unknown error',
-        chatModelId: graniteConfiguration.chatModelId ?? 'none',
-        tabModelId: graniteConfiguration.tabModelId ?? 'none',
-        embeddingsModelId: graniteConfiguration.embeddingsModelId ?? 'none',
+        chatModelId: chatModel ?? 'none',
+        tabModelId: tabModel ?? 'none',
+        embeddingsModelId: embeddingsModel ?? 'none',
       });
 
       // Show a generic error message to the user
@@ -375,7 +384,7 @@ export class SetupGranitePage {
       throw error;
     }
 
-    // Trigger the next UI flow after successful setup
+    // Display Continue Chat UI next
     commands.executeCommand("continue.continueGUIView.focus");
   }
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,1 +1,0 @@
-export const ExtensionID = 'redhat.vscode-granite';

--- a/webviews/src/ModelList.tsx
+++ b/webviews/src/ModelList.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 import Select from 'react-select';
 import { ProgressData } from '../../src/commons/progressData';
 import ProgressBar from './ProgressBar';
-import { StatusCheck } from './StatusCheck';
+import { StatusCheck, StatusValue } from './StatusCheck';
+import { ModelStatus } from '../../src/commons/statuses';
 
 export interface ModelOption {
     label: string;
@@ -15,7 +16,7 @@ interface ModelListProps {
     label: string;
     value: string | null;
     onChange: (option: ModelOption | null) => void;
-    status: boolean | null;
+    status: ModelStatus | null;
     options: ModelOption[];
     progress?: ProgressData;
     disabled?: boolean;
@@ -77,12 +78,51 @@ const ModelList: React.FC<ModelListProps> = ({ className, label, value, onChange
         );
     };
 
+    const getIconType = (status: ModelStatus | null): StatusValue | null => {
+        if (status === null) {
+            return null;
+        }
+        switch (status) {
+            case ModelStatus.installed:
+                return 'complete';
+            case ModelStatus.stale:
+                return 'partial';
+            case ModelStatus.installing:
+                return 'installing';
+        }
+        return 'missing';
+    };
+
+    const getTitle = (status: ModelStatus | null): string | undefined => {
+        switch (status) {
+            case ModelStatus.stale:
+                return 'There is a newer version of this model';
+            case ModelStatus.installed:
+                return 'This model is already installed';
+            case ModelStatus.installing:
+                return 'This model is being installed';
+            case ModelStatus.missing:
+                return 'This model will be installed';
+        }
+    };
+
+    const getStatusLabel = (status: ModelStatus): string => {
+        switch (status) {
+            case ModelStatus.stale:
+                return '(will be updated automatically)';
+            case ModelStatus.missing:
+                return '(will be pulled automatically)';
+            default:
+                return '';
+        }
+    };
+
     return (
         <div className="form-group">
             <div className='model-list--outer-wrapper'>
 
                 <label className='model-list--label' htmlFor={label}>
-                    <StatusCheck checked={status} />
+                    <StatusCheck type={getIconType(status)} title={getTitle(status)} />
                     <span>{label}:</span>
                 </label>
 
@@ -97,19 +137,18 @@ const ModelList: React.FC<ModelListProps> = ({ className, label, value, onChange
                         styles={customStyles}
                         formatOptionLabel={formatOptionLabel}
                     />
-                    {status === null ? null : !status && !progress && <span className='info-label' style={{ display: 'flex', alignItems: 'center' }}> (will be pulled automatically)</span>}
-
-                </div>
-            </div>
+                    {status !== null && status !== ModelStatus.installed && !progress && <span className='info-label' style={{ display: 'flex', alignItems: 'center' }}> {getStatusLabel(status)}</span>}
+                </div >
+            </div >
 
             <div className='progress-container'>
-                {!status && progress && (
+                {progress && (
                     <div id='progress' style={{ width: "100%", marginTop: "8px" }}>
                         <ProgressBar id={value!} data={progress} />
                     </div>
                 )}
             </div>
-        </div>
+        </div >
     );
 };
 

--- a/webviews/src/StatusCheck.tsx
+++ b/webviews/src/StatusCheck.tsx
@@ -1,12 +1,26 @@
-import { VscCircleLarge, VscCircleLargeFilled, VscPassFilled } from "react-icons/vsc";
+import { VscArrowCircleDown, VscCircleLarge, VscCircleLargeFilled, VscPass, VscPassFilled } from "react-icons/vsc";
+
+
+export type StatusValue = 'complete' | 'installing' | 'partial' | 'missing';
 
 export interface StatusCheckProps {
-  checked: boolean | null
+  type: StatusValue | null;
+  title?: string;
 }
 
-export const StatusCheck: React.FC<StatusCheckProps> = ({ checked }: StatusCheckProps) => {
-  return (checked === null ? (<VscCircleLargeFilled color="var(--vscode-textLink-foreground)" />) : (checked ?
-    <VscPassFilled color="var(--vscode-textLink-foreground)" /> :
-    <VscCircleLarge />
-  ));
+const DEFAULT_COLOR = "var(--vscode-textLink-foreground)";
+
+export const StatusCheck: React.FC<StatusCheckProps> = ({ type, title }: StatusCheckProps) => {
+  switch (type) {
+    case null:
+      return <VscCircleLargeFilled color={DEFAULT_COLOR} />;
+    case "complete":
+      return <VscPassFilled color={DEFAULT_COLOR} title={title} />;
+    case "installing":
+      return <VscArrowCircleDown color={DEFAULT_COLOR} title={title} />;
+    case "partial":
+      return <VscPass color={DEFAULT_COLOR} title={title} />;
+    default: //"missing"
+      return <VscCircleLarge title={title} />;
+  }
 };


### PR DESCRIPTION
fixes #67

- Models and Server statuses now have finer grain
- Model update detection is **very** hacky: connects to the ollama.com/library/[modelid] page and finds latest digest value by parsing HTML
- Because collecting latest model digest is slow, results are cached in memory once per VS Code session. Requests timeout after 3 sec.
- Model digests cache warmup performed before displaying the webview, to minimize perceived lag
- New tooltips on status icons
- New icon when downloading images

![Screenshot 2024-10-11 at 16 35 29](https://github.com/user-attachments/assets/1e0dde39-4866-47f3-9bea-0769230bc0e6)
